### PR TITLE
fix cross_street errors and add new treasure fields

### DIFF
--- a/controllers/treasuresController.js
+++ b/controllers/treasuresController.js
@@ -27,15 +27,15 @@ var createTreasure = function(req, res, next) {
         description: req.body.description,
         img_url: req.body.img_url,
         cross_street: req.body.cross_street,
-        city: req.body.city,
-        state: req.body.state,
+        // city: req.body.city,
+        // state: req.body.state,
         zipcode: req.body.zipcode,
         pirate_id: req.user.id
       });
 
   treasure.save(function(error) {
     if (error) res.json({message: 'Could not create treasure because: ' + error});
-    res.redirect("./treasures/" + newTreasure.id);
+    res.redirect("./treasures/" + treasure.id);
   });
 };
 

--- a/models/Treasure.js
+++ b/models/Treasure.js
@@ -4,7 +4,7 @@ var TreasureSchema = new mongoose.Schema({
     name: String,
     description: String,
     img_url: String,
-    street: String,
+    cross_street: String,
     city: {
         type: String,
         default: 'Los Angeles'
@@ -27,8 +27,7 @@ var TreasureSchema = new mongoose.Schema({
         default: Date.now
     },
     pirate_id: {
-        // type: mongoose.Schema.Types.ObjectId, ref: 'Pirate'
-        type: String
+        type: mongoose.Schema.Types.ObjectId, ref: 'Pirate'
     }
 });
 

--- a/views/treasures/new.ejs
+++ b/views/treasures/new.ejs
@@ -21,7 +21,7 @@
           <input id="cross_street" name="cross_street" type="text" class="validate">
           <label for="cross_street">Cross Street</label>
         </div>
-        <div class="input-field">
+<!--         <div class="input-field">
           <input id="city" name="city" type="text" class="validate">
           <label for="city">City</label>
         </div>
@@ -32,7 +32,7 @@
          <div class="input-field">
           <input type="text" pattern="[0-9]*" maxlength="5" min="0" id="zipcode"  name="zipcode">
           <label for="zipcode">Zip</label>
-        </div>
+        </div> -->
       <button class="btn waves-effect waves-light right" type="submit" name="action">Add Treasure
          <i class="material-icons">stars</i>
       </button>

--- a/views/treasures/show.ejs
+++ b/views/treasures/show.ejs
@@ -15,7 +15,7 @@
         </div>
         <div class="card-content">
           <%= treasure.description %>
-          <%= treasure.street %>
+          <%= treasure.cross_street %>
           <%= treasure.city %>
           <%= treasure.state %>
           <%= treasure.zipcode %>


### PR DESCRIPTION
we now have default values for city ('Los Angeles') and state '('ca'). These values will automatically be entered when a new treasure is entered. I also updated a few street properties with the new 'cross_street'
